### PR TITLE
display name added to RefElement component

### DIFF
--- a/todo-list/src/components/RefElement/index.tsx
+++ b/todo-list/src/components/RefElement/index.tsx
@@ -44,4 +44,6 @@ const RefElement = forwardRef<HTMLDivElement, ChildProps>(
   }
 );
 
+RefElement.displayName = "RefElement";
+
 export default RefElement;


### PR DESCRIPTION
During the deployment process got the Error: Component definition is missing display name react/display-name, apparently from the RefElement Component. 

I added to the displayName property a value to solve this issue. 
